### PR TITLE
Configure Next.js for Unsplash images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  images: {
+    domains: ['images.unsplash.com'],
+  },
+};
+
+module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- add `images.unsplash.com` to permitted image domains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e729643e4832da2e2abae474c17b3